### PR TITLE
cdの実装

### DIFF
--- a/srcs/builtin/builtin_cd.c
+++ b/srcs/builtin/builtin_cd.c
@@ -1,88 +1,155 @@
 
 #include "minishell.h"
 
-void	builtin_cd(int argc, char *argv[], t_dir *d_info)
+void	del_last_elem(t_list **pptr)
 {
-	char	*home_path;
-	int		ret;
-	int		i;
-	char	**split;
-	char	*tmp;
-	char	*tmp2;
+	int		len;
+	t_list	*tmp;
+	t_list	*tmp2;
 
-	if (d_info == NULL)
-		printf("d_info is NULL");
+	tmp = *pptr;
+	len = ms_lstsize(*pptr);
+	if (len == 1)
+	{
+		free((*pptr)->content);
+		free(*pptr);
+	}
+	else if (len == 2)
+	{
+		tmp2 = tmp->next;
+		tmp->next = NULL;
+		free(tmp2->content);
+		free(tmp2);
+	}
+	else if (len > 2)
+	{
+		while (tmp->next->next)
+			tmp = tmp->next;
+		tmp2 = tmp->next;
+		tmp->next = NULL;
+		free(tmp2->content);
+		free(tmp2);
+	}
+}
 
-	//引数が２つ以上あたえられたときはエラー
-	if (argc > 2)
-		ms_error("cd failed");
-
+char	*set_input_path(int argc, char **argv)
+{
 	if (argc == 1)
 	{
-		//引数がなにもなかった場合
-		//if (gerenv() != NULL)
-
-		home_path = ms_strdup(getenv("HOME"));
-		if (ms_strcmp(home_path, "") == 0)
-			ms_error("cd: HOME is empty.");
-		ret = chdir(home_path);
-		if (ret < 0)
+		if (getenv("HOME") == NULL)
 		{
-			ms_putendl_fd("cd failed", STDOUT);
+			ms_putendl_fd("minishell:HOME not set", STDERR);
+			return (NULL);
 		}
 		else
-		{
-			if (d_info->old_pwd != NULL)
-			{
-				free(d_info->old_pwd);
-				d_info->old_pwd = NULL;
-			}
-			d_info->old_pwd = d_info->pwd;
-			d_info->pwd = home_path;
-		}
+			return(ms_strdup(getenv("HOME")));
 	}
 	else
+		return(argv[1]);
+}
+
+t_list	*split_lst(char *str, char c)
+{
+	t_list	*lst;
+	char	**dir_pptr;
+	int		i;
+
+	dir_pptr = ms_split(str, c);
+	lst = ms_lstnew(dir_pptr[0]);
+	i = 1;
+	while (dir_pptr[i] != NULL)
 	{
-		//一つの引数があたえられた場合
-		ret = chdir(argv[1]);
-		if (ret < 0)
+		ms_lstadd_back(&lst, ms_lstnew(dir_pptr[i]));
+		i++;
+	}
+	return (lst);
+}
+
+char	*lst_to_string(t_list *list)
+{
+	char	*str;
+
+	str = NULL;
+	while (list != NULL)
+	{
+		if (str == NULL)
+			str = ms_strdup(ms_strjoin("/", (char *)list->content));
+		else
+			str = ms_strjoin(str, ms_strjoin("/", (char *)list->content));
+		list = list->next;
+	}
+	return (str);
+}
+
+char	*rewrite_absolute_path(t_list *dir_lst)
+{
+	char	*new_path;
+	t_list	*new_dir_lst;
+
+	new_dir_lst = NULL;
+	while (dir_lst != NULL)
+	{
+		if (ms_strcmp((char *)dir_lst->content, "..") == 0)
+			del_last_elem(&new_dir_lst);
+		else if (ms_strcmp((char *)dir_lst->content, ".") != 0)
 		{
-			ms_putendl_fd("cd failed", STDOUT);
+			if (ms_lstsize(new_dir_lst) == 0)
+				new_dir_lst = ms_lstnew(dir_lst->content);
+			else
+				ms_lstadd_back(&new_dir_lst, ms_lstnew(dir_lst->content));
 		}
+		dir_lst = dir_lst->next;
+	}
+	new_path = lst_to_string(new_dir_lst);
+	ms_lstclear(&new_dir_lst, free);
+	return (new_path);
+}
+
+char	*rewrite_relative_path(t_list *dir_lst, char *pwd)
+{
+	char	*new_path;
+	t_list	*new_pwd_lst;
+
+	new_pwd_lst = split_lst(pwd, '/');
+	while (dir_lst != NULL)
+	{
+		if (ms_strcmp(dir_lst->content, "..") == 0)
+			del_last_elem(&new_pwd_lst);
+		else if (ms_strcmp(dir_lst->content, ".") != 0)
+			ms_lstadd_back(&new_pwd_lst, ms_lstnew(dir_lst->content));
+		dir_lst = dir_lst->next;
+	}
+	new_path = lst_to_string(new_pwd_lst);
+	ms_lstclear(&new_pwd_lst, free);
+	return (new_path);
+}
+
+void	builtin_cd(int argc, char *argv[], t_dir *d_info)
+{
+	t_list		*dir_lst;
+	char		*input_path;
+	char		*new_pwd;
+
+	input_path = set_input_path(argc, argv);
+	if (input_path == NULL)
+		g_status = EXIT_FAILURE;
+	else
+	{
+		dir_lst = split_lst(input_path, '/');
+		if (input_path[0] == '/')
+			new_pwd = ms_strdup(rewrite_absolute_path(dir_lst));
+		else
+			new_pwd = ms_strdup(rewrite_relative_path(dir_lst, d_info->pwd));
+		if (chdir(new_pwd) < 0)
+			perror("minishell");
 		else
 		{
 			if (d_info->old_pwd != NULL)
-			{
 				free(d_info->old_pwd);
-				d_info->old_pwd = NULL;
-			}
-			d_info->old_pwd = d_info->pwd;
-
-			//絶対パス
-			if (argv[1][0] == '/')
-			{
-				tmp = ms_strdup("");
-				split = ms_split(argv[1], '/');
-				i = 0;
-				while (split[i] != NULL)
-				{
-					if (ms_strcmp(".", split[i]) == 0)
-						;
-					else if (ms_strcmp("..", split[i]) == 0)
-					{
-						tmp2 = tmp;
-						tmp = ms_substr(tmp2, 0, ms_strrchr(tmp2, '/') - tmp2);
-						free(tmp2);
-					}
-					else
-					{
-						tmp = ms_strappend(tmp, "/");
-						tmp = ms_strappend(tmp, split[i]);
-					}
-					i++;
-				}
-				d_info->pwd = tmp;
-			}
+			d_info->old_pwd = ms_strdup(d_info->pwd);
+			free(d_info->pwd);
+			d_info->pwd = ms_strdup(new_pwd);
+			free(new_pwd);
 		}
 	}
 }


### PR DESCRIPTION
/で分けたリストを用いて絶対パスと相対パス両方で実行可能になりました。
移動後のpwdを先に作った後にchdirをすることで、シンボリックリンクを含んだ移動も可能となったと思います！
時間のある時に確認していただけたらと思います。
関数が多くなってしまったので、また今度リファクタリングしましょう！！